### PR TITLE
Rely on IP address for metadata server

### DIFF
--- a/oauth2_plugin/oauth2_client.py
+++ b/oauth2_plugin/oauth2_client.py
@@ -65,14 +65,14 @@ token_exchange_lock = threading.Lock()
 
 DEFAULT_SCOPE = 'https://www.googleapis.com/auth/devstorage.full_control'
 
-META_TOKEN_URI = ('http://metadata/computeMetadata/v1/instance/'
-                  'service-accounts/default/token')
-
 META_HEADERS = {
     'X-Google-Metadata-Request': 'True'
 }
 
 METADATA_SERVER = 'http://169.254.169.254'
+
+META_TOKEN_URI = METADATA_SERVER + ('/computeMetadata/v1/instance/'
+                                    'service-accounts/default/token')
 
 
 # Note: this is copied from gsutil's gslib.cred_types. It should be kept in


### PR DESCRIPTION
The client code uses the hard-coded IP and "metadata" to contact the
GCE metadata host.  For maximum portability, don't rely on name
resolution.

We launched the default container found at https://index.docker.io/u/google/docker-registry/ on GCE and discovered the container could not resolve "metadata" and /etc/hosts is not writable in the image mentioned.  As a result, the public image was unusable for us.
