### PR TITLE
Update oauth2_client.py

### DIFF
--- a/oauth2_plugin/oauth2_client.py
+++ b/oauth2_plugin/oauth2_client.py
@@ -516,8 +516,8 @@ class OAuth2GCEClient(OAuth2Client):
       http = httplib2.Http()
       response, content = http.request(META_TOKEN_URI, method='GET',
                                        body=None, headers=META_HEADERS)
-    except Exception:
-      raise GsAccessTokenRefreshError()
+    except Exception as ex:
+      raise GsAccessTokenRefreshError(str(ex))
 
     if response.status == 200:
       d = simplejson.loads(content)


### PR DESCRIPTION
```
2014-06-02 13:21:51,379 DEBUG: Exception in worker process:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/gunicorn/arbiter.py", line 459, in spawn_worker
    worker.init_process()
  File "/usr/lib/python2.7/dist-packages/gunicorn/workers/ggevent.py", line 98, in init_process
    super(GeventWorker, self).init_process()
  File "/usr/lib/python2.7/dist-packages/gunicorn/workers/base.py", line 99, in init_process
    self.wsgi = self.app.wsgi()
  File "/usr/lib/python2.7/dist-packages/gunicorn/app/base.py", line 101, in wsgi
    self.callable = self.load()
  File "/usr/lib/python2.7/dist-packages/gunicorn/app/wsgiapp.py", line 24, in load
    return util.import_app(self.app_uri)
  File "/usr/lib/python2.7/dist-packages/gunicorn/util.py", line 291, in import_app
    __import__(module)
  File "/docker-registry/wsgi.py", line 11, in <module>
    import registry
  File "/docker-registry/registry/__init__.py", line 5, in <module>
    from .tags import *
  File "/docker-registry/registry/tags.py", line 18, in <module>
    store = storage.load()
  File "/docker-registry/lib/storage/__init__.py", line 152, in load
    store = gcs.GSStorage(cfg)
  File "/docker-registry/lib/storage/gcs.py", line 21, in __init__
    BotoStorage.__init__(self, config)
  File "/docker-registry/lib/storage/boto_base.py", line 107, in __init__
    self._config.boto_bucket)
  File "/usr/local/lib/python2.7/dist-packages/boto/gs/connection.py", line 128, in get_bucket
    bucket.get_all_keys(headers, maxkeys=0)
  File "/usr/local/lib/python2.7/dist-packages/boto/s3/bucket.py", line 471, in get_all_keys
    '', headers, **params)
  File "/usr/local/lib/python2.7/dist-packages/boto/s3/bucket.py", line 399, in _get_all
    query_args=query_args)
  File "/usr/local/lib/python2.7/dist-packages/boto/s3/connection.py", line 633, in make_request
    retry_handler=retry_handler
  File "/usr/local/lib/python2.7/dist-packages/boto/connection.py", line 1046, in make_request
    retry_handler=retry_handler)
  File "/usr/local/lib/python2.7/dist-packages/boto/connection.py", line 908, in _mexe
    request.authorize(connection=self)
  File "/usr/local/lib/python2.7/dist-packages/boto/connection.py", line 379, in authorize
    connection._auth_handler.add_auth(self, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/oauth2_plugin/oauth2_plugin.py", line 48, in add_auth
    self.oauth2_client.GetAuthorizationHeader()
  File "/usr/local/lib/python2.7/dist-packages/oauth2_plugin/oauth2_client.py", line 344, in GetAuthorizationHeader
    return 'Bearer %s' % self.GetAccessToken().token
  File "/usr/local/lib/python2.7/dist-packages/oauth2_plugin/oauth2_client.py", line 315, in GetAccessToken
    access_token = self.FetchAccessToken()
  File "/usr/local/lib/python2.7/dist-packages/retry_decorator/retry_decorator.py", line 20, in f_retry
    return f(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/oauth2_plugin/oauth2_client.py", line 521, in FetchAccessToken
    raise GsAccessTokenRefreshError()
TypeError: __init__() takes exactly 2 arguments (1 given)
```
