### PR TITLE
Add fallback if metadata server cannot be resolved

### DIFF
--- a/oauth2_plugin/oauth2_client.py
+++ b/oauth2_plugin/oauth2_client.py
@@ -520,7 +520,7 @@ class OAuth2GCEClient(OAuth2Client):
                                        body=None, headers=META_HEADERS)
     except Exception as ex:
       exMsg = str(ex)
-      if exMsg == '':
+      if exMsg == 'Unable to find the server at metadata':
         try:
           response, content = http.request(FALLBACK_META_TOKEN_URI, 
                                            method='GET',


### PR DESCRIPTION
I'm currently trying to run a docker repository server van cannot edit the hosts file. Adding this fallback can serve as a hack until the hosts file is setup correctly. see #6 and #7
