### PR TITLE
Remove deprecation warning.

### DIFF
--- a/gcs_oauth2_boto_plugin/oauth2_client.py
+++ b/gcs_oauth2_boto_plugin/oauth2_client.py
@@ -30,7 +30,7 @@ notice.
 
 from __future__ import absolute_import
 
-import cgi
+import urlparse
 import datetime
 import errno
 from hashlib import sha1
@@ -687,7 +687,7 @@ class AccessToken(object):
 
     def GetValue(d, key):
       return (d.get(key, [None]))[0]
-    kv = cgi.parse_qs(query)
+    kv = urlparse.parse_qs(query)
     if not kv['token']:
       return None
     expiry = None


### PR DESCRIPTION
/usr/lib/python2.7/dist-packages/gcs_oauth2_boto_plugin/oauth2_client.py:584: PendingDeprecationWarning: cgi.parse_qs is deprecated, use urlparse.parse_qs instead

  kv = cgi.parse_qs(query)

cgi.parse_qs is deprecated and in fact it only calls urlparse.parse_qs:
https://hg.python.org/releasing/2.7.9/file/753a8f457ddc/Lib/cgi.py#l180
