### PR TITLE
Deprecate X-Google-Metadata-Request in favor new Metadata-Flavor header

### DIFF
--- a/gcs_oauth2_boto_plugin/oauth2_client.py
+++ b/gcs_oauth2_boto_plugin/oauth2_client.py
@@ -74,7 +74,7 @@ META_TOKEN_URI = (METADATA_SERVER + '/computeMetadata/v1/instance/'
                   'service-accounts/default/token')
 
 META_HEADERS = {
-    'X-Google-Metadata-Request': 'True'
+    'Metadata-Flavor': 'Google'
 }
 
 


### PR DESCRIPTION
We are deprecating the use of the X-Google-Metadata-Request header in favor
of the latest header, Metadata-Flavor.

The transition is explained here:

https://cloud.google.com/compute/docs/metadata#transitioning