### PR TITLE
Bump version to 1.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ requires = [
 
 setup(
     name='gcs-oauth2-boto-plugin',
-    version='1.9',
+    version='1.10',
     url='https://developers.google.com/storage/docs/gspythonlibrary',
     download_url=('https://github.com/GoogleCloudPlatform'
                   '/gcs-oauth2-boto-plugin'),


### PR DESCRIPTION
We'll have to do a release of this, then pull the changes into gsutil at the same time we grab an updated copy of oauth2client.