### PR TITLE
Fix support for oauth2client 2.0

### DIFF
--- a/gcs_oauth2_boto_plugin/oauth2_client.py
+++ b/gcs_oauth2_boto_plugin/oauth2_client.py
@@ -58,7 +58,13 @@ from retry_decorator.retry_decorator import retry as Retry
 import socks
 
 if HAS_CRYPTO:
-  from oauth2client.client import SignedJwtAssertionCredentials
+  try:
+    from oauth2client.client import SignedJwtAssertionCredentials
+    USE_NEW_OAUTH=False
+    ServiceAccountCredentials = service_account._ServiceAccountCredentials
+  except ImportError:
+    from oauth2client.service_account import ServiceAccountCredentials
+    USE_NEW_OAUTH=True
 
 LOG = logging.getLogger('oauth2_client')
 
@@ -424,9 +430,14 @@ class OAuth2ServiceAccountClient(_BaseOAuth2ServiceAccountClient):
 
   def GetCredentials(self):
     if HAS_CRYPTO:
-      return SignedJwtAssertionCredentials(
-          self._client_id, self._private_key, scope=DEFAULT_SCOPE,
-          private_key_password=self._password)
+      if USE_NEW_OAUTH:
+        return ServiceAccountCredentials._from_p12_keyfile_contents(
+            self._client_id, self._private_key, private_key_password=self._password,
+            scopes=DEFAULT_SCOPE)
+      else:
+        return SignedJwtAssertionCredentials(
+            self._client_id, self._private_key, scope=DEFAULT_SCOPE,
+            private_key_password=self._password)
     else:
       raise MissingDependencyError(
           'Service account authentication requires PyOpenSSL. Please install '
@@ -438,7 +449,7 @@ class OAuth2ServiceAccountClient(_BaseOAuth2ServiceAccountClient):
 # be refactored into oauth2client directly in a way that allows for setting of
 # user agent and scopes. https://github.com/google/oauth2client/issues/164
 # pylint: disable=protected-access
-class ServiceAccountCredentials(service_account._ServiceAccountCredentials):
+class ServiceAccountCredentials(ServiceAccountCredentials):
 
   def to_json(self):
     self.service_account_name = self._service_account_email

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto>=2.29.1
 httplib2>=0.8
-oauth2client==1.5.2
+oauth2client>=1.5.2
 pyOpenSSL>=0.13
 SocksiPy-branch==1.01
 retry_decorator>=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ for the machine in a thread- and process-safe fashion.
 requires = [
     'boto>=2.29.1',
     'httplib2>=0.8',
-    'oauth2client==1.5.2',
+    'oauth2client>=1.5.2',
     'pyOpenSSL>=0.13',
     # Not using 1.02 because of:
     #   https://code.google.com/p/socksipy-branch/issues/detail?id=3


### PR DESCRIPTION
Hello Google :)

gcs_oauth2_boto_plugin requires oauth2client==1.5.2 but latest google-api-python-client
requires  oauth2client 2.0. Otherwise it gives us the error below.

This PR adds the bindings that allow gcs_oauth2_boto_plugin to work with both oauth2client 1.5 and 2.0

```
WARNING:root:No module named contrib.locked_file
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/googleapiclient/discovery_cache/__init__.py", line 38, in autodetect
    from . import file_cache
  File "/usr/local/lib/python2.7/dist-packages/googleapiclient/discovery_cache/file_cache.py", line 32, in <module>
    from oauth2client.contrib.locked_file import LockedFile
ImportError: No module named contrib.locked_file
```