### PR TITLE
Fix Python 3.x compatibility

### DIFF
--- a/gcs_oauth2_boto_plugin/oauth2_client.py
+++ b/gcs_oauth2_boto_plugin/oauth2_client.py
@@ -28,7 +28,7 @@ notice.
 # tokens (in the python API client oauth2client, there is a single class that
 # encapsulates both refresh and access tokens).
 
-from __future__ import absolute_import
+
 
 import cgi
 import datetime
@@ -40,7 +40,7 @@ import os
 import socket
 import tempfile
 import threading
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 # pylint: disable=g-import-not-at-top
 if os.environ.get('USER_AGENT'):
@@ -122,7 +122,7 @@ except ImportError:
           retval.token_expiry = datetime.datetime.strptime(
               data['token_expiry'], EXPIRY_FORMAT)
         return retval
-      except KeyError, e:
+      except KeyError as e:
         raise Exception('Your JSON credentials are invalid; '
                         'missing required entry %s.' % e[0])
   # pylint: enable=protected-access
@@ -274,7 +274,7 @@ class FileSystemTokenCache(TokenCache):
       flags |= os.O_BINARY
 
     try:
-      fd = os.open(cache_file, flags, 0600)
+      fd = os.open(cache_file, flags, 'r')
     except (OSError, IOError) as e:
       LOG.warning('FileSystemTokenCache.PutToken: '
                   'Failed to create cache file %s: %s', cache_file, e)
@@ -633,7 +633,7 @@ class OAuth2UserAccountClient(OAuth2Client):
       return AccessToken(
           credentials.access_token, credentials.token_expiry,
           datetime_strategy=self.datetime_strategy)
-    except AccessTokenRefreshError, e:
+    except AccessTokenRefreshError as e:
       if 'Invalid response 403' in e.message:
         # This is the most we can do at the moment to accurately detect rate
         # limiting errors since they come back as 403s with no further
@@ -669,7 +669,7 @@ class OAuth2GCEClient(OAuth2Client):
       http = httplib2.Http()
       response, content = http.request(META_TOKEN_URI, method='GET',
                                        body=None, headers=META_HEADERS)
-    except Exception, e:
+    except Exception as e:
       raise GsAccessTokenRefreshError(e)
 
     if response.status == 200:
@@ -695,7 +695,7 @@ def _IsGCE():
     # this approach, we'll avoid having to enumerate all possible non-transient
     # socket errors.
     return False
-  except Exception, e:  # pylint: disable=broad-except
+  except Exception as e:  # pylint: disable=broad-except
     LOG.warning("Failed to determine whether we're running on GCE, so we'll"
                 "assume that we aren't: %s", e)
     return False
@@ -743,7 +743,7 @@ class AccessToken(object):
       t = self.expiry
       tupl = (t.year, t.month, t.day, t.hour, t.minute, t.second, t.microsecond)
       kv['expiry'] = ','.join([str(i) for i in tupl])
-    return urllib.urlencode(kv)
+    return urllib.parse.urlencode(kv)
 
   def ShouldRefresh(self, time_delta=300):
     """Whether the access token needs to be refreshed.


### PR DESCRIPTION
`oauth2_client.py` has some Python 2 syntax that is causing the module to fail when imported in Python 3.6 as referenced in issue #29 and #30. This is fixed by running `2to3` over `oauth2_client.py` and then correcting one things that 2to3 didn't catch — `os.open` expects a string for file mode rather than a unix mode octal.