### PR TITLE
cgi.parse_qs is deprecated, using urllib.parse.parse_qs instead

### DIFF
--- a/gcs_oauth2_boto_plugin/oauth2_client.py
+++ b/gcs_oauth2_boto_plugin/oauth2_client.py
@@ -30,7 +30,6 @@ notice.
 
 from __future__ import absolute_import
 
-import cgi
 import datetime
 import errno
 from hashlib import sha1
@@ -735,7 +734,7 @@ class AccessToken(object):
 
     def GetValue(d, key):
       return (d.get(key, [None]))[0]
-    kv = cgi.parse_qs(query)
+    kv = urllib.parse.parse_qs(query)
     if not kv['token']:
       return None
     expiry = None


### PR DESCRIPTION
https://docs.python.org/3/library/cgi.html#cgi.parse_qs

`cgi.parse_qs` is deprecated.