### PR TITLE
fix python3 json lib error in oauth2_helper.py

### DIFF
--- a/gcs_oauth2_boto_plugin/oauth2_helper.py
+++ b/gcs_oauth2_boto_plugin/oauth2_helper.py
@@ -82,7 +82,7 @@ def OAuth2ClientFromBotoConfig(
 
     json_key_dict = None
     try:
-      json_key_dict = json.loads(private_key)
+      json_key_dict = json.loads(private_key.decode('utf-8'))
     except ValueError:
       pass
     if json_key_dict:


### PR DESCRIPTION
When using this as a python module from python3 and providing it with a key file, it reads with 'rb', which causes python3 json library to choke:

```python
Traceback (most recent call last):
  File "./repl.py", line 23, in <module>
  elif token_cache_type == 'in_memory':
    connection = boto.connect_s3(provider='google', host='storage.googleapis.com')
  File "/usr/local/lib/python3.5/dist-packages/boto/__init__.py", line 141, in connect_s3
    return S3Connection(aws_access_key_id, aws_secret_access_key, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/boto/s3/connection.py", line 194, in __init__
    validate_certs=validate_certs, profile_name=profile_name)
  File "/usr/local/lib/python3.5/dist-packages/boto/connection.py", line 569, in __init__
    host, config, self.provider, self._required_auth_capability())
  File "/usr/local/lib/python3.5/dist-packages/boto/auth.py", line 1011, in get_auth_handler
    ready_handlers.append(handler(host, config, provider))
  File "/usr/local/lib/python3.5/dist-packages/gcs_oauth2_boto_plugin/oauth2_plugin.py", line 56, in __init__
    config, cred_type=oauth2_client.CredTypes.OAUTH2_SERVICE_ACCOUNT)
  File "/usr/local/lib/python3.5/dist-packages/gcs_oauth2_boto_plugin/oauth2_helper.py", line 85, in OAuth2ClientFromBotoConfig
    json_key_dict = json.loads(private_key)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```
There are two potential fixes;  read with 'r' instead of 'rb', or decode the bytes into a string for json.  I chose the latter, in case the fallback file format requires the bytes, but I did not test with the fallback format.

Sample code to cause this from [this gist](https://gist.github.com/grivescorbett/c1f87a1643c7cee5f1dd5dafe9cb8ac1):

```python
import boto
import gcs_oauth2_boto_plugin

boto.config.add_section('Credentials')
boto.config.set('Credentials', 'gs_service_key_file', '/path/to/account/file.json')
boto.config.set('Credentials', 'gs_service_client_id', 'user@project.iam.gserviceaccount.com')
connection = boto.connect_s3(provider='google', host='storage.googleapis.com')
```