### PR TITLE
Use io.open for compatibility

### DIFF
--- a/gcs_oauth2_boto_plugin/oauth2_helper.py
+++ b/gcs_oauth2_boto_plugin/oauth2_helper.py
@@ -16,6 +16,7 @@
 
 from __future__ import absolute_import
 
+import io
 import json
 import os
 import sys
@@ -77,7 +78,7 @@ def OAuth2ClientFromBotoConfig(
   if cred_type == oauth2_client.CredTypes.OAUTH2_SERVICE_ACCOUNT:
     service_client_id = config.get('Credentials', 'gs_service_client_id', '')
     private_key_filename = config.get('Credentials', 'gs_service_key_file', '')
-    with open(private_key_filename, 'rb') as private_key_file:
+    with io.open(private_key_filename, 'r', encoding='utf-8') as private_key_file:
       private_key = private_key_file.read()
 
     json_key_dict = None


### PR DESCRIPTION
In Python 3.x, using gsutil with a keyfile in Windows environments causes an `expected str() got bytes` error. Using `io.open()` here helps alleviate this.

CI test logs to gsutil Windows runs, pointing to gcp/gsutil : ioopen branch, whose build script is modified to checkout gcs-oauth2 plugin on this branch: `go/gsutil-ioopen-pr-logs`

See also: https://github.com/GoogleCloudPlatform/gsutil/pull/747
Bug: b/130652889