### PR TITLE
Improve logic for detecting PKCS 12 keys

### DIFF
--- a/gcs_oauth2_boto_plugin/oauth2_helper.py
+++ b/gcs_oauth2_boto_plugin/oauth2_helper.py
@@ -91,20 +91,26 @@ def OAuth2ClientFromBotoConfig(
       pass
 
     if keyfile_is_utf8:
-      json_key_dict = json.loads(private_key)
-      for json_entry in ('client_id', 'client_email', 'private_key_id',
-                         'private_key'):
-        if json_entry not in json_key_dict:
-          raise Exception('The JSON private key file at %s '
-                          'did not contain the required entry: %s' %
-                          (private_key_filename, json_entry))
-      return oauth2_client.OAuth2JsonServiceAccountClient(
-          json_key_dict, access_token_cache=token_cache,
-          auth_uri=provider_authorization_uri, token_uri=provider_token_uri,
-          disable_ssl_certificate_validation=not(config.getbool(
-              'Boto', 'https_validate_certificates', True)),
-          proxy_host=proxy_host, proxy_port=proxy_port,
-          proxy_user=proxy_user, proxy_pass=proxy_pass)
+      json_key_dict = None
+      try:
+        json_key_dict = json.loads(private_key)
+      except ValueError:
+        raise Exception('Could not parse JSON keyfile "%s" as valid JSON' %
+                        private_key_filename)
+      if json_key_dict:
+        for json_entry in ('client_id', 'client_email', 'private_key_id',
+                           'private_key'):
+          if json_entry not in json_key_dict:
+            raise Exception('The JSON private key file at %s '
+                            'did not contain the required entry: %s' %
+                            (private_key_filename, json_entry))
+        return oauth2_client.OAuth2JsonServiceAccountClient(
+            json_key_dict, access_token_cache=token_cache,
+            auth_uri=provider_authorization_uri, token_uri=provider_token_uri,
+            disable_ssl_certificate_validation=not(config.getbool(
+                'Boto', 'https_validate_certificates', True)),
+            proxy_host=proxy_host, proxy_port=proxy_port,
+            proxy_user=proxy_user, proxy_pass=proxy_pass)
     else:
       key_file_pass = config.get('Credentials', 'gs_service_key_file_password',
                                  GOOGLE_OAUTH2_DEFAULT_FILE_PASSWORD)

--- a/gcs_oauth2_boto_plugin/oauth2_helper.py
+++ b/gcs_oauth2_boto_plugin/oauth2_helper.py
@@ -91,26 +91,24 @@ def OAuth2ClientFromBotoConfig(
       pass
 
     if keyfile_is_utf8:
-      json_key_dict = None
       try:
         json_key_dict = json.loads(private_key)
       except ValueError:
         raise Exception('Could not parse JSON keyfile "%s" as valid JSON' %
                         private_key_filename)
-      if json_key_dict:
-        for json_entry in ('client_id', 'client_email', 'private_key_id',
-                           'private_key'):
-          if json_entry not in json_key_dict:
-            raise Exception('The JSON private key file at %s '
-                            'did not contain the required entry: %s' %
-                            (private_key_filename, json_entry))
-        return oauth2_client.OAuth2JsonServiceAccountClient(
-            json_key_dict, access_token_cache=token_cache,
-            auth_uri=provider_authorization_uri, token_uri=provider_token_uri,
-            disable_ssl_certificate_validation=not(config.getbool(
-                'Boto', 'https_validate_certificates', True)),
-            proxy_host=proxy_host, proxy_port=proxy_port,
-            proxy_user=proxy_user, proxy_pass=proxy_pass)
+      for json_entry in ('client_id', 'client_email', 'private_key_id',
+                         'private_key'):
+        if json_entry not in json_key_dict:
+          raise Exception('The JSON private key file at %s '
+                          'did not contain the required entry: %s' %
+                          (private_key_filename, json_entry))
+      return oauth2_client.OAuth2JsonServiceAccountClient(
+          json_key_dict, access_token_cache=token_cache,
+          auth_uri=provider_authorization_uri, token_uri=provider_token_uri,
+          disable_ssl_certificate_validation=not(config.getbool(
+              'Boto', 'https_validate_certificates', True)),
+          proxy_host=proxy_host, proxy_port=proxy_port,
+          proxy_user=proxy_user, proxy_pass=proxy_pass)
     else:
       key_file_pass = config.get('Credentials', 'gs_service_key_file_password',
                                  GOOGLE_OAUTH2_DEFAULT_FILE_PASSWORD)

--- a/gcs_oauth2_boto_plugin/oauth2_helper.py
+++ b/gcs_oauth2_boto_plugin/oauth2_helper.py
@@ -16,7 +16,6 @@
 
 from __future__ import absolute_import
 
-import binascii
 import io
 import json
 import os
@@ -93,7 +92,6 @@ def OAuth2ClientFromBotoConfig(
   if cred_type == oauth2_client.CredTypes.OAUTH2_SERVICE_ACCOUNT:
     service_client_id = config.get('Credentials', 'gs_service_client_id', '')
     private_key_filename = config.get('Credentials', 'gs_service_key_file', '')
-    private_key = _GetPrivateKey(private_key_filename)
     with io.open(private_key_filename, 'rb') as private_key_file:
       private_key = private_key_file.read()
 

--- a/gcs_oauth2_boto_plugin/oauth2_helper.py
+++ b/gcs_oauth2_boto_plugin/oauth2_helper.py
@@ -91,26 +91,20 @@ def OAuth2ClientFromBotoConfig(
       pass
 
     if keyfile_is_utf8:
-      json_key_dict = None
-      try:
-        json_key_dict = json.loads(private_key)
-      except ValueError:
-        raise Exception('Could not parse JSON keyfile "%s" as valid JSON' %
-                        private_key_filename)
-      if json_key_dict:
-        for json_entry in ('client_id', 'client_email', 'private_key_id',
-                           'private_key'):
-          if json_entry not in json_key_dict:
-            raise Exception('The JSON private key file at %s '
-                            'did not contain the required entry: %s' %
-                            (private_key_filename, json_entry))
-        return oauth2_client.OAuth2JsonServiceAccountClient(
-            json_key_dict, access_token_cache=token_cache,
-            auth_uri=provider_authorization_uri, token_uri=provider_token_uri,
-            disable_ssl_certificate_validation=not(config.getbool(
-                'Boto', 'https_validate_certificates', True)),
-            proxy_host=proxy_host, proxy_port=proxy_port,
-            proxy_user=proxy_user, proxy_pass=proxy_pass)
+      json_key_dict = json.loads(private_key)
+      for json_entry in ('client_id', 'client_email', 'private_key_id',
+                         'private_key'):
+        if json_entry not in json_key_dict:
+          raise Exception('The JSON private key file at %s '
+                          'did not contain the required entry: %s' %
+                          (private_key_filename, json_entry))
+      return oauth2_client.OAuth2JsonServiceAccountClient(
+          json_key_dict, access_token_cache=token_cache,
+          auth_uri=provider_authorization_uri, token_uri=provider_token_uri,
+          disable_ssl_certificate_validation=not(config.getbool(
+              'Boto', 'https_validate_certificates', True)),
+          proxy_host=proxy_host, proxy_port=proxy_port,
+          proxy_user=proxy_user, proxy_pass=proxy_pass)
     else:
       key_file_pass = config.get('Credentials', 'gs_service_key_file_password',
                                  GOOGLE_OAUTH2_DEFAULT_FILE_PASSWORD)

--- a/gcs_oauth2_boto_plugin/oauth2_helper.py
+++ b/gcs_oauth2_boto_plugin/oauth2_helper.py
@@ -95,7 +95,8 @@ def OAuth2ClientFromBotoConfig(
       try:
         json_key_dict = json.loads(private_key)
       except ValueError:
-        pass
+        raise Exception('Could not parse JSON keyfile "%s" as valid JSON' %
+                        private_key_filename)
       if json_key_dict:
         for json_entry in ('client_id', 'client_email', 'private_key_id',
                            'private_key'):

--- a/gcs_oauth2_boto_plugin/oauth2_helper.py
+++ b/gcs_oauth2_boto_plugin/oauth2_helper.py
@@ -28,6 +28,7 @@ import oauth2client.client
 
 from six.moves import input  # pylint: disable=redefined-builtin
 
+UTF8 = 'utf-8'
 CLIENT_ID = None
 CLIENT_SECRET = None
 
@@ -38,20 +39,6 @@ GOOGLE_OAUTH2_PROVIDER_TOKEN_URI = (
 GOOGLE_OAUTH2_DEFAULT_FILE_PASSWORD = 'notasecret'
 
 OOB_REDIRECT_URI = 'urn:ietf:wg:oauth:2.0:oob'
-
-
-def _MaybeTextFile(filename):
-  """Check if text file based on file(1)
-  Implementation stolen shamelessly from:
-  https://stackoverflow.com/a/7392391/2873090
-  Args:
-    filename: String describing a path to a file
-  Returns:
-    Boolean: True if the first 1024 bytes seem to indicate a text file
-  """
-  textchars = bytearray({7, 8, 9, 10, 12, 13, 27} |
-                        set(range(0x20, 0x100)) - {0x7f})
-  return lambda bytes: bool(bytes.translate(None, textchars))
 
 
 def OAuth2ClientFromBotoConfig(


### PR DESCRIPTION
When attempting to load a PKCS 12 key in Python 3, io.open would
throw an error since it tried to apply UTF-8 text encoding to the
key file, which was not a compatible text file.

Changes tested using .p12 key from our pre-release tests.