### PR TITLE
Ensure unicode content string from http.request

### DIFF
--- a/gcs_oauth2_boto_plugin/oauth2_client.py
+++ b/gcs_oauth2_boto_plugin/oauth2_client.py
@@ -673,6 +673,7 @@ class OAuth2GCEClient(OAuth2Client):
       http = httplib2.Http()
       response, content = http.request(META_TOKEN_URI, method='GET',
                                        body=None, headers=META_HEADERS)
+      content = six.ensure_text(content)
     except Exception as e:
       raise GsAccessTokenRefreshError(e)
 


### PR DESCRIPTION
For Python 2 / 3 compatibility, we need to ensure that the content
string returned from httplib2.Http().request is Unicode. json.loads in
Python 3 only handles Unicode strings, necessitating this change.