### PR TITLE
Use unittest.mock when available

### DIFF
--- a/gcs_oauth2_boto_plugin/test_oauth2_client.py
+++ b/gcs_oauth2_boto_plugin/test_oauth2_client.py
@@ -26,7 +26,11 @@ import unittest
 from freezegun import freeze_time
 from gcs_oauth2_boto_plugin import oauth2_client
 import httplib2
-import mock
+
+try:
+  from unittest import mock
+except ImportError:
+  import mock
 
 LOG = logging.getLogger('test_oauth2_client')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ retry_decorator>=1.0.0
 six>=1.6.1
 # Extra requirements only needed for testing, 'dev' label in setup.py.
 freezegun
-mock
+mock;python_version<"3.3"

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ requires = [
 extras_require = {
     'dev': [
         'freezegun',
-        'mock',
+        'mock;python_version<"3.3"',
     ],
 }
 


### PR DESCRIPTION
Instead of unconditionally relying on external 'mock' module, use
built-in 'unittest.mock' in py3.3+.