### PR TITLE
Use an older version of rsa for python <= 3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+rsa<=4.0; python_version < "3.5"
 boto>=2.29.1
 google-reauth>=0.1.0
 httplib2>=0.8

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,6 @@
 
 """Setup installation module for gcs-oauth2-boto-plugin."""
 
-from sys import version_info as version
-
 from setuptools import find_packages
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,8 @@ for the machine in a thread- and process-safe fashion.
 """
 
 requires = [
+    # rsa>4, from oauth2client (deprecated), does not support python 2 and 3.4.
+    'rsa<=4.0; python_version < "3.5"',
     'boto>=2.29.1',
     'google-reauth>=0.1.0',
     'httplib2>=0.8',
@@ -42,10 +44,6 @@ requires = [
     'retry_decorator>=1.0.0',
     'six>=1.12.0'
 ]
-
-# rsa>4, from oauth2client (deprecated), does not support python 2 and 3.4.
-if version.major == 2 or (version.major == 3 and version.minor == 4):
-  requires = ['rsa<=4.0'] + requires
 
 extras_require = {
     'dev': [

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@
 
 """Setup installation module for gcs-oauth2-boto-plugin."""
 
+from sys import version_info as version
+
 from setuptools import find_packages
 from setuptools import setup
 
@@ -40,6 +42,10 @@ requires = [
     'retry_decorator>=1.0.0',
     'six>=1.12.0'
 ]
+
+# rsa>4, from oauth2client (deprecated), does not support python 2 and 3.4.
+if version.major == 2 or (version.major == 3 and version.minor == 4):
+  requires = ['rsa<=4.0'] + requires
 
 extras_require = {
     'dev': [


### PR DESCRIPTION
The rsa library, which is a requirement for the oauth2client dependency, dropped support for python 2 and 3.4 after version 4 (https://pypi.org/project/rsa/4.1.1/), breaking compatibility with those versions for projects that use this one as a dependency.

Ideally we'd add this change in oauth2client, but as it is now deprecated and read-only that is not possible.