### PR TITLE
Remove socksi-py dependency

### DIFF
--- a/gcs_oauth2_boto_plugin/oauth2_client.py
+++ b/gcs_oauth2_boto_plugin/oauth2_client.py
@@ -52,7 +52,6 @@ import oauth2client.client
 import oauth2client.service_account
 from google_reauth import reauth_creds
 import retry_decorator.retry_decorator
-import socks
 
 import six
 from six import BytesIO
@@ -287,7 +286,7 @@ class OAuth2Client(object):
     self.disable_ssl_certificate_validation = disable_ssl_certificate_validation
     self.ca_certs_file = ca_certs_file
     if proxy_host and proxy_port:
-      self._proxy_info = httplib2.ProxyInfo(socks.PROXY_TYPE_HTTP,
+      self._proxy_info = httplib2.ProxyInfo(httplib2.socks.PROXY_TYPE_HTTP,
                                             proxy_host,
                                             proxy_port,
                                             proxy_user=proxy_user,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
 rsa<=4.0; python_version < "3.5"
 boto>=2.29.1
 google-reauth>=0.1.0
-httplib2>=0.8
+httplib2>=0.18
 oauth2client>=2.2.0
 pyOpenSSL>=0.13
-SocksiPy-branch==1.01
 retry_decorator>=1.0.0
 six>=1.6.1
 # Extra requirements only needed for testing, 'dev' label in setup.py.

--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,9 @@ requires = [
     'rsa<=4.0; python_version < "3.5"',
     'boto>=2.29.1',
     'google-reauth>=0.1.0',
-    'httplib2>=0.8',
+    'httplib2>=0.18',
     'oauth2client>=2.2.0',
     'pyOpenSSL>=0.13',
-    # Not using 1.02 because of:
-    #   https://code.google.com/p/socksipy-branch/issues/detail?id=3
-    'SocksiPy-branch==1.01',
     'retry_decorator>=1.0.0',
     'six>=1.12.0'
 ]
@@ -52,7 +49,7 @@ extras_require = {
 
 setup(
     name='gcs-oauth2-boto-plugin',
-    version='2.6',
+    version='2.7',
     url='https://developers.google.com/storage/docs/gspythonlibrary',
     download_url=('https://github.com/GoogleCloudPlatform'
                   '/gcs-oauth2-boto-plugin'),


### PR DESCRIPTION
Socki-py is breaking for Python3 when we try to do Proxy authentication. Removing this dependency and instead using the socks.py module present in the httplib2 lib.