### PR TITLE
Peg RSA version to patch vulnerability but maintain PY2 compatibility.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-rsa<=4.0; python_version < "3.5"
+rsa==4.3; python_version < "3.5"
 boto>=2.29.1
 google-reauth>=0.1.0
 httplib2>=0.18

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ for the machine in a thread- and process-safe fashion.
 """
 
 requires = [
-    # rsa>4, from oauth2client (deprecated), does not support python 2 and 3.4.
-    'rsa<=4.0; python_version < "3.5"',
+    # Other versions of rsa>4 do not support Python 2.
+    'rsa==4.3; python_version < "3.5"',
     'boto>=2.29.1',
     'google-reauth>=0.1.0',
     'httplib2>=0.18',


### PR DESCRIPTION
RSA change log: https://github.com/sybrenstuvel/python-rsa/blob/main/CHANGELOG.md#version-41---released-2020-06-10

Package tests passed.