### PR TITLE
Add google-auth and google-auth-httplib2 to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ requires = [
     'rsa==4.7.2',
     'boto>=2.29.1',
     'google-reauth>=0.1.0',
+    'google-auth==2.17.0',
+    'google-auth-httplib2>=0.2.0',
     'httplib2>=0.18',
     'oauth2client>=2.2.0',
     'pyOpenSSL>=0.13',


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/gcs-oauth2-boto-plugin/pull/62 added these dependencies to `requirements.txt`, but neglected to include them in `setup.py`. As a result, installing `pip install gsutil` doesn't automatically install these dependencies, resulting in:

```
File "/usr/local/lib/python3.9/site-packages/gcs_oauth2_boto_plugin/oauth2_client.py", line 57, in <module>
  from google_auth_httplib2 import Request as GoogleAuthRequest
ModuleNotFoundError: No module named 'google_auth_httplib2'
```

Closes #67