### PR TITLE
update google-auth to 2.39.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ httplib2>=0.18
 oauth2client>=2.2.0
 pyOpenSSL>=0.13
 retry_decorator>=1.0.0
-six>=1.6.1
+six>=1.12.0
 # Extra requirements only needed for testing, 'dev' label in setup.py.
 freezegun
 mock;python_version<"3.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 rsa==4.7.2
 boto>=2.29.1
 google-reauth>=0.1.0
-google-auth==2.17.0
+google-auth==2.39.0
 google-auth-httplib2>=0.2.0
 httplib2>=0.18
 oauth2client>=2.2.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ requires = [
     'pyOpenSSL>=0.13',
     'retry_decorator>=1.0.0',
     'six>=1.12.0',
-    'google-auth==2.17.0',
+    'google-auth==2.39.0',
     'google-auth-httplib2>=0.2.0'
 ]
 


### PR DESCRIPTION
`gsutil` updated the `google-auth` to `v2.39.0` in support for `Python 3.13`.
Updating the `google-auth` in `gcs-oauth2-boto-plugin` to the same to avoid dependency conflict.

Updating `six` in requirements.txt to maintain consistency with setup.py